### PR TITLE
Add Skip on Upstream change

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
@@ -41,6 +41,9 @@ limitations under the License.
         <f:entry title="${%scm.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-scm-skip.html">
             <f:checkbox name="skipOnScmChange" checked="${instance.skipOnScmChange()}"/>
         </f:entry>
+        <f:entry title="${%upstream.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-upstream-skip.html">
+            <f:checkbox name="skipOnUpstreamChange" checked="${instance.skipOnUpstreamChange()}"/>
+        </f:entry>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
@@ -20,3 +20,4 @@ suppression.file=Suppression file
 enable.verbose.logging=Enable verbose logging
 disable.autoupdate=Disable CPE auto-update
 scm.skip=Skip if triggered by SCM changes
+upstream.skip=Skip if triggered by Upstream changes

--- a/src/main/webapp/help-upstream-skip.html
+++ b/src/main/webapp/help-upstream-skip.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, a Dependency-Check analysis will not be performed if the job was triggered by an upstream change.
+</div>


### PR DESCRIPTION
Add Skip on Upstream change, to avoid Dependency Check analysis when for example a snapshot dependency module trig a new build 
