### PR TITLE
Allow custom database configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -70,8 +70,9 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
 
     @DataBoundConstructor // Fields in config.jelly must match the parameter names
     public DependencyCheckBuilder(String scanpath, String outdir, String datadir, String suppressionFile,
-                                  String zipExtensions, Boolean isAutoupdateDisabled, Boolean isVerboseLoggingEnabled,
-                                  Boolean includeHtmlReports, Boolean skipOnScmChange, Boolean skipOnUpstreamChange,
+				  String zipExtensions, Boolean isAutoupdateDisabled,
+				  Boolean isVerboseLoggingEnabled, Boolean includeHtmlReports,
+				  Boolean skipOnScmChange, Boolean skipOnUpstreamChange,
                                   Boolean useMavenArtifactsScanPath) {
         this.scanpath = scanpath;
         this.outdir = outdir;
@@ -226,6 +227,23 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
         configureProxySettings(options, this.getDescriptor().getIsNvdProxyBypassed());
 
         // Begin configuration for Builder specific settings
+
+	// SETUP DB CONNECTION
+        if (StringUtils.isNotBlank(this.getDescriptor().dbconnstr)) {
+            options.setDbconnstr(this.getDescriptor().dbconnstr);
+        }
+        if (StringUtils.isNotBlank(this.getDescriptor().dbdriver)) {
+            options.setDbdriver(this.getDescriptor().dbdriver);
+        }
+        if (StringUtils.isNotBlank(this.getDescriptor().dbpath)) {
+            options.setDbpath(this.getDescriptor().dbpath);
+        }
+        if (StringUtils.isNotBlank(this.getDescriptor().dbuser)) {
+            options.setDbuser(this.getDescriptor().dbuser);
+        }
+        if (StringUtils.isNotBlank(this.getDescriptor().dbpassword)) {
+            options.setDbpassword(this.getDescriptor().dbpassword);
+        }
 
         // SUPPRESSION FILE
         if (StringUtils.isNotBlank(suppressionFile)) {
@@ -384,6 +402,31 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
          * Specifies the data mirroring type (scheme) to use
          */
         private int dataMirroringType;
+
+        /**
+         * Specifies the custom database connection string
+	 */
+	private String dbconnstr;
+
+        /**
+         * Specifies the custom database driver name
+	 */
+	private String dbdriver;
+
+        /**
+         * Specifies the custom database driver path
+	 */
+	private String dbpath;
+
+	/**
+         * Specifies the custom database login user
+	 */
+	private String dbuser;
+
+        /**
+         * Specifies the custom database login password
+	 */
+	private String dbpassword;
 
         /**
          * Specifies if to download the NVD data feeds the proxy defined in Jenkins should be bypassed.
@@ -622,6 +665,11 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
             nexusUrl = formData.getString("nexusUrl");
             isNexusProxyBypassed = formData.getBoolean("isNexusProxyBypassed");
             monoPath = formData.getString("monoPath");
+            dbconnstr = formData.getString("dbconnstr");
+            dbdriver = formData.getString("dbdriver");
+            dbpath = formData.getString("dbpath");
+            dbuser = formData.getString("dbuser");
+            dbpassword = formData.getString("dbpassword");
             tempPath = formData.getString("tempPath");
             isQuickQueryTimestampEnabled = formData.getBoolean("isQuickQueryTimestampEnabled");
             save();
@@ -789,7 +837,47 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
             return tempPath;
         }
 
-        /**
+	/**
+	 * Retrieves the database connection string that DependencyCheck will use. This is a per-build config item.
+	 * This method must match the value in <tt>config.jelly</tt>.
+	 */
+	public String getDbconnstr() {
+	    return dbconnstr;
+	}
+
+	/**
+	 * Retrieves the database driver name that DependencyCheck will use. This is a per-build config item.
+	 * This method must match the value in <tt>config.jelly</tt>.
+	 */
+	public String getDbdriver() {
+	    return dbdriver;
+	}
+
+	/**
+	 * Retrieves the database driver path that DependencyCheck will use. This is a per-build config item.
+	 * This method must match the value in <tt>config.jelly</tt>.
+	 */
+	public String getDbpath() {
+	    return dbpath;
+	}
+
+	/**
+	 * Retrieves the database user that DependencyCheck will use. This is a per-build config item.
+	 * This method must match the value in <tt>config.jelly</tt>.
+	 */
+	public String getDbuser() {
+	    return dbuser;
+	}
+
+	/**
+	 * Retrieves the database password that DependencyCheck will use. This is a per-build config item.
+	 * This method must match the value in <tt>config.jelly</tt>.
+	 */
+	public String getDbpassword() {
+	    return dbpassword;
+	}
+
+       /**
          * Returns if QuickQuery is enabled or not. If enabled, HTTP HEAD will be used.
          */
         public boolean getIsQuickQueryTimestampEnabled() {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -19,6 +19,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.BuildListener;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.commons.lang.StringUtils;
 import org.owasp.dependencycheck.Engine;
 import org.owasp.dependencycheck.data.nvdcve.CveDB;
 import org.owasp.dependencycheck.data.nvdcve.DatabaseException;
@@ -202,9 +203,26 @@ public class DependencyCheckExecutor implements Serializable {
      */
     private void populateSettings() {
         Settings.initialize();
-        Settings.setString(Settings.KEYS.DB_CONNECTION_STRING, "jdbc:h2:file:%s;AUTOCOMMIT=ON;FILE_LOCK=SERIALIZED;");
-        Settings.setBoolean(Settings.KEYS.AUTO_UPDATE, options.isAutoUpdate());
-        Settings.setString(Settings.KEYS.DATA_DIRECTORY, options.getDataDirectory());
+	if (options.getDbconnstr() == null) {
+	    Settings.setString(Settings.KEYS.DB_CONNECTION_STRING, "jdbc:h2:file:%s;AUTOCOMMIT=ON;FILE_LOCK=SERIALIZED;");
+	}
+	if (StringUtils.isNotBlank(options.getDbconnstr())) {
+	    Settings.setString(Settings.KEYS.DB_CONNECTION_STRING, options.getDbconnstr());
+            if (StringUtils.isNotBlank(options.getDbdriver())) {
+                Settings.setString(Settings.KEYS.DB_DRIVER_NAME, options.getDbdriver());
+            }
+            if (StringUtils.isNotBlank(options.getDbpath())) {
+                Settings.setString(Settings.KEYS.DB_DRIVER_PATH, options.getDbpath());
+            }
+            if (StringUtils.isNotBlank(options.getDbuser())) {
+                Settings.setString(Settings.KEYS.DB_USER, options.getDbuser());
+            }
+            if (StringUtils.isNotBlank(options.getDbpassword())) {
+                Settings.setString(Settings.KEYS.DB_PASSWORD, options.getDbpassword());
+            }
+	}
+	Settings.setBoolean(Settings.KEYS.AUTO_UPDATE, options.isAutoUpdate());
+	Settings.setString(Settings.KEYS.DATA_DIRECTORY, options.getDataDirectory());
 
         if (options.getDataMirroringType() != 0) {
             if (options.getCveUrl12Modified() != null) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck;
 
+import org.apache.commons.lang.StringUtils;
 import org.owasp.dependencycheck.reporting.ReportGenerator;
 
 import java.io.Serializable;
@@ -56,6 +57,31 @@ public class Options implements Serializable {
      * Specifies the data directory.
      */
     private String dataDirectory;
+
+    /**
+     * Specifies the database connection string.
+     */
+    private String dbconnstr;
+
+    /**
+     * Specifies the database driver name.
+     */
+    private String dbdriver;
+
+    /**
+     * Specifies the database driver path.
+     */
+    private String dbpath;
+
+    /**
+     * Specifies the database user.
+     */
+    private String dbuser;
+
+    /**
+     * Specifies the database password.
+     */
+    private String dbpassword;
 
     /**
      * Boolean value (true/false) whether or not the evidence collected
@@ -319,6 +345,76 @@ public class Options implements Serializable {
      */
     public void setDataDirectory(String dataDirectory) {
         this.dataDirectory = dataDirectory;
+    }
+
+    /**
+     * Sets the database connection string.
+     */
+    public void setDbconnstr(String dbconnstr) {
+        this.dbconnstr = dbconnstr;
+    }
+
+    /**
+     * Gets the database connection string.
+     */
+    public String getDbconnstr() {
+        return dbconnstr;
+    }
+
+    /**
+     * Sets the database driver name.
+     */
+    public void setDbdriver(String dbdriver) {
+        this.dbdriver = dbdriver;
+    }
+
+    /**
+     * Gets the database driver name.
+     */
+    public String getDbdriver() {
+        return dbdriver;
+    }
+
+    /**
+     * Sets the database driver path.
+     */
+    public void setDbpath(String dbpath) {
+        this.dbpath = dbpath;
+    }
+
+    /**
+     * Gets the database driver path.
+     */
+    public String getDbpath() {
+        return dbpath;
+    }
+
+    /**
+     * Sets the database user.
+     */
+    public void setDbuser(String dbuser) {
+        this.dbuser = dbuser;
+    }
+
+    /**
+     * Gets the database user.
+     */
+    public String getDbuser() {
+        return dbuser;
+    }
+
+    /**
+     * Sets the database password.
+     */
+    public void setDbpassword(String dbpassword) {
+        this.dbpassword = dbpassword;
+    }
+
+    /**
+     * Gets the database password.
+     */
+    public String getDbpassword() {
+        return dbpassword;
     }
 
     /**
@@ -864,6 +960,27 @@ public class Options implements Serializable {
         } else {
             sb.append(" -dataDirectory = ").append(dataDirectory).append("\n");
         }
+	if (dbconnstr != null) {
+	    sb.append(" -connectionString = ").append(dbconnstr).append("\n");
+	}
+	if (dbdriver != null) {
+	    sb.append(" -dbDriverName = ").append(dbdriver).append("\n");
+	}
+	if (dbpath != null) {
+	    sb.append(" -dbDriverPath = ").append(dbpath).append("\n");
+	}
+	if (dbuser != null) {
+	    sb.append(" -dbUser = ").append(dbuser).append("\n");
+	}
+	if (dbpassword != null) {
+            /*
+             * It is likely that the global configuration, set by the
+             * Jenkins administrator, includes a password that should
+             * not be exposed to any user able to read the console
+             * log from any job using this plugin.
+             */
+	    sb.append(" -dbPassword = ").append("OBSCURED").append("\n");
+	}
         if (verboseLoggingFile != null) {
             sb.append(" -verboseLogFile = ").append(verboseLoggingFile).append("\n");
         }

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.jelly
@@ -25,6 +25,21 @@ limitations under the License.
 
         <f:advanced>
 
+        <f:entry title="${%db.connection.string}" field="dbconnstr" help="/plugin/dependency-check-jenkins-plugin/help-database-connstring.html">
+            <f:textbox id="dbconnstr"/>
+        </f:entry>
+        <f:entry title="${%db.driver.name}" field="dbdriver" id="dbdriver" help="/plugin/dependency-check-jenkins-plugin/help-database-dbdriver.html">
+            <f:textbox id="dbdriver"/>
+        </f:entry>
+        <f:entry title="${%db.driver.path}" field="dbpath" id="dbpath" help="/plugin/dependency-check-jenkins-plugin/help-database-path.html">
+            <f:textbox id="dbpath"/>
+        </f:entry>
+        <f:entry title="${%db.user}" field="dbuser" id="dbuser" help="/plugin/dependency-check-jenkins-plugin/help-database-dbuser.html">
+            <f:textbox id="dbuser"/>
+        </f:entry>
+        <f:entry title="${%db.password}" field="dbpassword" id="dbpassword" help="/plugin/dependency-check-jenkins-plugin/help-database-dbpassword.html">
+            <f:textbox id="dbpassword"/>
+        </f:entry>
             <f:entry title="${%mirror.title}"
                      help="/plugin/dependency-check-jenkins-plugin/help-datamirror.html">
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.properties
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+db.connection.string=Database connection string
+db.driver.name=Database driver name
+db.driver.path=Database driver path
+db.user=Database user
+db.password=Database password
 mirror.title=Data mirroring scheme
 mirror.none=None
 mirror.nist=NIST CPE/CVE

--- a/src/main/webapp/help-database-connstring.html
+++ b/src/main/webapp/help-database-connstring.html
@@ -1,0 +1,6 @@
+<div>
+    Specify the database connection string. This can be any standard
+    jdbc connection string supported by the local system.
+    By default, Dependency-Check uses a local h2 database:
+    <pre>jdbc:h2:file:%s;AUTOCOMMIT=ON;FILE_LOCK=SERIALIZED;</pre>
+</div>

--- a/src/main/webapp/help-database-dbdriver.html
+++ b/src/main/webapp/help-database-dbdriver.html
@@ -1,0 +1,5 @@
+<div>
+    Specify the database driver class name.
+    For example, connect to a MySQL database with:
+    <pre>com.mysql.jdbc.Driver</pre>
+</div>

--- a/src/main/webapp/help-database-dbpassword.html
+++ b/src/main/webapp/help-database-dbpassword.html
@@ -1,0 +1,3 @@
+<div>
+    Specify the password to authenticate the database connection.
+</div>

--- a/src/main/webapp/help-database-dbuser.html
+++ b/src/main/webapp/help-database-dbuser.html
@@ -1,0 +1,3 @@
+<div>
+    Specify the username as which to connect to the database.
+</div>

--- a/src/main/webapp/help-database-path.html
+++ b/src/main/webapp/help-database-path.html
@@ -1,0 +1,5 @@
+<div>
+    Specify the database driver class path.
+    For example, if a MySQL database is used, then the value might be:
+    <pre>/usr/share/java/mysql-connector-java.jar</pre>
+</div>


### PR DESCRIPTION
Improve OWASP DC Jenkins Plugin to allow a customized database
connection configuration, such as to a centralized MySQL or Postgres
vulnerability database. An embedded h2 database is still used by
default to execute the OWASP dependency check if no custom database
configuration is provided.

This is an improved version to use global config instead of per-job config
and replace pull request 4