### PR TITLE
adding hintsFile configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -271,7 +271,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
         if (StringUtils.isNotBlank(hintsFile)) {
             String tmpHintsFile = substituteVariable(build, listener, hintsFile.trim());
             try {
-                // Try to set the suppression file as a URL
+                // Try to set the hints file as a URL
                 options.setHintsFile(new URL(tmpHintsFile).toExternalForm());
             } catch (MalformedURLException e) {
                 // If the format is not a valid URL, set it as a FilePath type

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -61,6 +61,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
     private final String outdir;
     private final String datadir;
     private final String suppressionFile;
+    private final String hintsFile;
     private final String zipExtensions;
     private final boolean isAutoupdateDisabled;
     private final boolean isVerboseLoggingEnabled;
@@ -70,7 +71,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
 
     @DataBoundConstructor // Fields in config.jelly must match the parameter names
     public DependencyCheckBuilder(String scanpath, String outdir, String datadir, String suppressionFile,
-				  String zipExtensions, Boolean isAutoupdateDisabled,
+				  String hintsFile, String zipExtensions, Boolean isAutoupdateDisabled,
 				  Boolean isVerboseLoggingEnabled, Boolean includeHtmlReports,
 				  Boolean skipOnScmChange, Boolean skipOnUpstreamChange,
                                   Boolean useMavenArtifactsScanPath) {
@@ -78,6 +79,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
         this.outdir = outdir;
         this.datadir = datadir;
         this.suppressionFile = suppressionFile;
+        this.hintsFile = hintsFile;
         this.zipExtensions = zipExtensions;
         this.isAutoupdateDisabled = (isAutoupdateDisabled != null) && isAutoupdateDisabled;
         this.isVerboseLoggingEnabled = (isVerboseLoggingEnabled != null) && isVerboseLoggingEnabled;
@@ -117,6 +119,14 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
      */
     public String getSuppressionFile() {
         return suppressionFile;
+    }
+
+    /**
+     * Retrieves the hints file that DependencyCheck will use. This is a per-build config item.
+     * This method must match the value in <tt>config.jelly</tt>.
+     */
+    public String getHintsFile() {
+        return hintsFile;
     }
 
     /**
@@ -254,6 +264,18 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder imple
             } catch (MalformedURLException e) {
                 // If the format is not a valid URL, set it as a FilePath type
                 options.setSuppressionFile(new FilePath(build.getWorkspace(), tmpSuppressionFile).getRemote());
+            }
+        }
+
+        // HINTS FILE
+        if (StringUtils.isNotBlank(hintsFile)) {
+            String tmpHintsFile = substituteVariable(build, listener, hintsFile.trim());
+            try {
+                // Try to set the suppression file as a URL
+                options.setHintsFile(new URL(tmpHintsFile).toExternalForm());
+            } catch (MalformedURLException e) {
+                // If the format is not a valid URL, set it as a FilePath type
+                options.setHintsFile(new FilePath(build.getWorkspace(), tmpHintsFile).getRemote());
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -295,6 +295,9 @@ public class DependencyCheckExecutor implements Serializable {
         if (options.getSuppressionFile() != null) {
             Settings.setString(Settings.KEYS.SUPPRESSION_FILE, options.getSuppressionFile());
         }
+        if (options.getHintsFile() != null) {
+            Settings.setString(Settings.KEYS.HINTS_FILE, options.getHintsFile());
+        }
         if (options.getZipExtensions() != null) {
             Settings.setString(Settings.KEYS.ADDITIONAL_ZIP_EXTENSIONS, options.getZipExtensions());
         }
@@ -327,6 +330,20 @@ public class DependencyCheckExecutor implements Serializable {
                     if (!suppressionFile.exists()) {
                         log(Messages.Warning_Suppression_NonExist());
                         options.setSuppressionFile(null);
+                    }
+                }
+            }
+
+            if (options.getHintsFile() != null) {
+                try {
+                    // Test of the hintsFile is a URL or not
+                    new URL(options.getHintsFile());
+                } catch (MalformedURLException e) {
+                    // Hints file was not a URL, so it must be a file path.
+                    final File hintsFile = new File(options.getHintsFile());
+                    if (!hintsFile.exists()) {
+                        log(Messages.Warning_Hints_NonExist());
+                        options.setHintsFile(null);
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -295,6 +295,7 @@ public class DependencyCheckExecutor implements Serializable {
         if (options.getSuppressionFile() != null) {
             Settings.setString(Settings.KEYS.SUPPRESSION_FILE, options.getSuppressionFile());
         }
+        // The hints file can either be a file on the file system or a URL.
         if (options.getHintsFile() != null) {
             Settings.setString(Settings.KEYS.HINTS_FILE, options.getHintsFile());
         }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -115,6 +115,11 @@ public class Options implements Serializable {
     private String suppressionFile;
 
     /**
+     * Specifies the hints file to use
+     */
+    private String hintsFile;
+
+    /**
      * Specifies the file extensions to be treated a ZIP
      */
     private String zipExtensions;
@@ -513,6 +518,20 @@ public class Options implements Serializable {
      */
     public void setSuppressionFile(String file) {
         this.suppressionFile = file;
+    }
+
+    /**
+     * Returns the hints file.
+     */
+    public String getHintsFile() {
+        return hintsFile;
+    }
+
+    /**
+     * Sets the hints file to use.
+     */
+    public void setHintsFile(String file) {
+        this.hintsFile = file;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -1042,6 +1042,9 @@ public class Options implements Serializable {
         if (suppressionFile != null) {
             sb.append(" -suppressionFile = ").append(suppressionFile).append("\n");
         }
+        if (hintsFile != null) {
+            sb.append(" -hintsFile = ").append(hintsFile).append("\n");
+        }
         if (zipExtensions != null) {
             sb.append(" -zipExtensions = ").append(zipExtensions).append("\n");
         }

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
@@ -37,6 +37,9 @@ limitations under the License.
         <f:entry title="${%suppression.file}" field="suppressionFile" help="/plugin/dependency-check-jenkins-plugin/help-suppression-file.html">
             <f:textbox id="suppressionFile"/>
         </f:entry>
+        <f:entry title="${%hints.file}" field="hintsFile" help="/plugin/dependency-check-jenkins-plugin/help-hints-file.html">
+            <f:textbox id="hintsFile"/>
+        </f:entry>
         <f:entry title="${%extensions.zip}" field="zipExtensions" help="/plugin/dependency-check-jenkins-plugin/help-extensions-zip.html">
             <f:textbox id="zipExtensions"/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
@@ -18,6 +18,7 @@ output.directory=Output directory
 generate.htmlreports=Generate optional HTML reports
 data.directory=Data directory
 suppression.file=Suppression file
+hints.file=Hints file
 extensions.zip=ZIP extensions
 enable.verbose.logging=Enable verbose logging
 disable.autoupdate=Disable NVD auto-update

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/Messages.properties
@@ -55,6 +55,8 @@ Failure.Collection=One or more exceptions were thrown while executing Dependency
 
 Warning.Suppression.NonExist=WARNING: Suppression file does not exist. Omitting.
 Error.Suppression.NonExist=ERROR: An error occurred attempting to validate the existence of suppression file.
+Warning.Hints.NonExist=WARNING: Hints file does not exist. Omitting.
+Error.Hints.NonExist=ERROR: An error occurred attempting to validate the existence of Hints file.
 Error.Output.Directory.Create=ERROR: Unable to create output directory
 Error.Data.Directory.Create=ERROR: Unable to create data directory
 

--- a/src/main/webapp/help-hints-file.html
+++ b/src/main/webapp/help-hints-file.html
@@ -1,0 +1,5 @@
+<div>
+    The optional hints file to use. Dependency-Check will reference
+    this file, if specified, during analysis and add evidence to any dependency
+    matched in the hints file.
+</div>


### PR DESCRIPTION
duplicate how suppression file configuration works for hints file to allow users to add their own hints xml file to dependency-check-core. 
Tested using mvn hpi:run; 
- hintsfile field is there 
- help file is accessible
- verified missing file gets logged, 
- verified valid file gets used 
