### PR TITLE
Avoid NullPointerException if exception doesn't have a cause

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -106,7 +106,9 @@ public class DependencyCheckExecutor implements Serializable {
             log(Messages.Failure_Collection());
             for (Throwable t: ec.getExceptions()) {
                 log("Exception Caught: " + t.getClass().getCanonicalName());
-                log("Cause: " + t.getCause().getMessage());
+		if (t.getCause() != null && t.getCause().getMessage() != null) {
+                    log("Cause: " + t.getCause().getMessage());
+		}
                 log("Message: " + t.getMessage());
             }
         } finally {


### PR DESCRIPTION
Avoid the following NullPointerException, which happened to me on version v1.4.4:
```
[DependencyCheck] OWASP Dependency-Check Plugin v1.4.4
[DependencyCheck] Executing Dependency-Check with the following options:
[DependencyCheck]  -name = XXXXXXX-dependencyCheck
[DependencyCheck]  -scanPath = XXXXXXX
[DependencyCheck]  -outputDirectory = XXXXXXX
[DependencyCheck]  -dataDirectory = XXXXXXX
[DependencyCheck]  -dataMirroringType = none
[DependencyCheck]  -proxyServer = XXXXXXX
[DependencyCheck]  -proxyPort = XXXX
[DependencyCheck]  -isQuickQueryTimestampEnabled = true
[DependencyCheck]  -useMavenArtifactsScanPath = false
[DependencyCheck]  -jarAnalyzerEnabled = true
[DependencyCheck]  -nodeJsAnalyzerEnabled = true
[DependencyCheck]  -composerLockAnalyzerEnabled = true
[DependencyCheck]  -pythonAnalyzerEnabled = true
[DependencyCheck]  -rubyGemAnalyzerEnabled = true
[DependencyCheck]  -cocoaPodsAnalyzerEnabled = true
[DependencyCheck]  -swiftPackageManagerAnalyzerEnabled = true
[DependencyCheck]  -archiveAnalyzerEnabled = true
[DependencyCheck]  -assemblyAnalyzerEnabled = true
[DependencyCheck]  -centralAnalyzerEnabled = true
[DependencyCheck]  -nuspecAnalyzerEnabled = false
[DependencyCheck]  -nexusAnalyzerEnabled = false
[DependencyCheck]  -autoconfAnalyzerEnabled = true
[DependencyCheck]  -cmakeAnalyzerEnabled = true
[DependencyCheck]  -opensslAnalyzerEnabled = true
[DependencyCheck]  -showEvidence = true
[DependencyCheck]  -format = ALL
[DependencyCheck]  -autoUpdate = true
[DependencyCheck]  -updateOnly = false
[DependencyCheck] Scanning: XXXXXXX
[DependencyCheck] Analyzing Dependencies
[DependencyCheck] One or more exceptions were thrown while executing Dependency-Check
[DependencyCheck] Exception Caught: org.owasp.dependencycheck.analyzer.exception.AnalysisException
ERROR: Build step failed with exception
java.lang.NullPointerException
	at org.jenkinsci.plugins.DependencyCheck.DependencyCheckExecutor.performBuild(DependencyCheckExecutor.java:109)
	at org.jenkinsci.plugins.DependencyCheck.AbstractDependencyCheckBuilder$2.call(AbstractDependencyCheckBuilder.java:97)
	at org.jenkinsci.plugins.DependencyCheck.AbstractDependencyCheckBuilder$2.call(AbstractDependencyCheckBuilder.java:94)
	at hudson.remoting.UserRequest.perform(UserRequest.java:121)
	at hudson.remoting.UserRequest.perform(UserRequest.java:49)
	at hudson.remoting.Request$2.run(Request.java:325)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask$Sync.innerRun(Unknown Source)
	at java.util.concurrent.FutureTask.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at hudson.remoting.Engine$1$1.run(Engine.java:69)
	at java.lang.Thread.run(Unknown Source)
	at ......remote call to swintoolsint03(Native Method)
	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1433)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:253)
	at hudson.remoting.Channel.call(Channel.java:797)
	at org.jenkinsci.plugins.DependencyCheck.AbstractDependencyCheckBuilder.perform(AbstractDependencyCheckBuilder.java:94)
	at org.jenkinsci.plugins.DependencyCheck.DependencyCheckBuilder.perform(DependencyCheckBuilder.java:209)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
	at hudson.model.Build$BuildExecution.build(Build.java:205)
	at hudson.model.Build$BuildExecution.doRun(Build.java:162)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
	at hudson.model.Run.execute(Run.java:1720)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
Build step 'Invoke OWASP Dependency-Check analysis' marked build as failure
[DependencyCheck] Skipping publisher since build result is FAILURE
Finished: FAILURE
```
