### PR TITLE
Fix verbose logging.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractDependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractDependencyCheckBuilder.java
@@ -198,12 +198,6 @@ public abstract class AbstractDependencyCheckBuilder extends Builder implements 
         }
         options.setOutputDirectory(outDirPath.getRemote());
 
-        // LOGGING
-        final FilePath log = new FilePath(workspace, "dependency-check.log");
-        if (isVerboseLoggingEnabled) {
-            options.setVerboseLoggingFile(log.getRemote());
-        }
-
         options.setWorkspace(workspace.getRemote());
 
         // If temp path has been specified, use it, otherwise Dependency-Check will default to the Java temp path

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -138,7 +138,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
      * Retrieves whether verbose logging is enabled or not. This is a per-build config item.
      * This method must match the value in <tt>config.jelly</tt>.
      */
-    public boolean getIsVerboseLoggingEnabled() {
+    public boolean isVerboseLoggingEnabled() {
         return isVerboseLoggingEnabled;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -105,11 +105,6 @@ public class Options implements Serializable {
     private boolean updateOnly = false;
 
     /**
-     * Specifies the verbose logging file to use
-     */
-    private String verboseLoggingFile;
-
-    /**
      * Specifies the suppression file to use
      */
     private String suppressionFile;
@@ -499,21 +494,6 @@ public class Options implements Serializable {
      */
     public void setUpdateOnly(boolean updateOnly) {
         this.updateOnly = updateOnly;
-    }
-
-    /**
-     * Returns the verbose logging file.
-     */
-    public String getVerboseLoggingFile() {
-        return verboseLoggingFile;
-    }
-
-    /**
-     * Sets whether verbose logging of the Dependency-Check engine and analyzers
-     * is enabled.
-     */
-    public void setVerboseLoggingFile(String file) {
-        this.verboseLoggingFile = file;
     }
 
     /**
@@ -1067,9 +1047,6 @@ public class Options implements Serializable {
              * log from any job using this plugin.
              */
             sb.append(" -dbPassword = ").append("OBSCURED").append("\n");
-        }
-        if (verboseLoggingFile != null) {
-            sb.append(" -verboseLogFile = ").append(verboseLoggingFile).append("\n");
         }
         if (suppressionFile != null) {
             sb.append(" -suppressionFile = ").append(suppressionFile).append("\n");


### PR DESCRIPTION
* Use the correct method name so the property gets saved when using the `Invoke OWASP Dependency-Check analysis` build step
* Remove false advertising around the verbose log file location