### PR TITLE
Fix saving the job flags.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -126,7 +126,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
      * Retrieves whether auto update should be disabled or not. This is a per-build config item.
      * This method must match the value in <tt>config.jelly</tt>.
      */
-    public boolean getIsAutoupdateDisabled() {
+    public boolean isAutoupdateDisabled() {
         return isAutoupdateDisabled;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
@@ -47,13 +47,13 @@ limitations under the License.
             <f:checkbox id="isAutoupdateDisabled" name="isAutoupdateDisabled" checked="${instance.isAutoupdateDisabled()}"/>
         </f:entry>
         <f:entry title="${%generate.htmlreports}" description="" help="/plugin/dependency-check-jenkins-plugin/help-format.html">
-            <f:checkbox id="includeHtmlReports" name="includeHtmlReports" checked="${instance.includeHtmlReports()}"/>
+            <f:checkbox id="includeHtmlReports" name="includeHtmlReports" checked="${instance.getIncludeHtmlReports()}"/>
         </f:entry>
         <f:entry title="${%scm.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-scm-skip.html">
-            <f:checkbox id="skipOnScmChange" name="skipOnScmChange" checked="${instance.skipOnScmChange()}"/>
+            <f:checkbox id="skipOnScmChange" name="skipOnScmChange" checked="${instance.getSkipOnScmChange()}"/>
         </f:entry>
         <f:entry title="${%upstream.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-upstream-skip.html">
-            <f:checkbox id="skipOnUpstreamChange" name="skipOnUpstreamChange" checked="${instance.skipOnUpstreamChange()}"/>
+            <f:checkbox id="skipOnUpstreamChange" name="skipOnUpstreamChange" checked="${instance.getSkipOnUpstreamChange()}"/>
         </f:entry>
     </f:advanced>
 


### PR DESCRIPTION
Use the correct method names in `config.jelly` so that the flags for the analyzer step get saved and loaded properly.

Note that I changed the method name to `isAutoupdateDisabled` to more closely follow Java method naming conventions.