### PR TITLE
Adding option to disable marking build failed due to dependency check error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
+*.iml
 /target/
 /work/

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -59,13 +59,13 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
     private final boolean includeHtmlReports;
     private final boolean includeJsonReports;
     private final boolean includeCsvReports;
-
+    private final boolean isFailOnErrorDisabled;
 
     @DataBoundConstructor // Fields in config.jelly must match the parameter names
     public DependencyCheckBuilder(String scanpath, String outdir, String datadir, String suppressionFile,
 				  String hintsFile, String zipExtensions, Boolean isAutoupdateDisabled,
 				  Boolean includeHtmlReports, Boolean includeJsonReports, Boolean includeCsvReports,
-                  Boolean skipOnScmChange, Boolean skipOnUpstreamChange) {
+                  Boolean skipOnScmChange, Boolean skipOnUpstreamChange, Boolean isFailOnErrorDisabled) {
         this.scanpath = scanpath;
         this.outdir = outdir;
         this.datadir = datadir;
@@ -78,6 +78,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
         this.includeCsvReports = (includeCsvReports != null) && includeCsvReports;
         this.skipOnScmChange = (skipOnScmChange != null) && skipOnScmChange;
         this.skipOnUpstreamChange = (skipOnUpstreamChange != null) && skipOnUpstreamChange;
+        this.isFailOnErrorDisabled = (isFailOnErrorDisabled != null) && isFailOnErrorDisabled;
     }
 
     /**
@@ -179,6 +180,13 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
     public boolean getSkipOnUpstreamChange() {
         return skipOnUpstreamChange;
     }
+
+    /**
+     * Retrieves whether build failure on error should be disabled or not.
+     * This is a per-build config item.
+     * This method must match the value in <tt>config.jelly</tt>.
+     */
+    public boolean getIsFailOnErrorDisabled() { return isFailOnErrorDisabled; }
 
     /**
      * This method is called whenever the DependencyCheck build step is executed.
@@ -309,6 +317,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
         }
 
         options.setAutoUpdate(!isAutoupdateDisabled);
+        options.setFailOnError(!isFailOnErrorDisabled);
 
         if (includeHtmlReports) {
             options.addFormat(ReportGenerator.Format.HTML);

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -100,6 +100,11 @@ public class Options implements Serializable {
     private boolean autoUpdate = true;
 
     /**
+     * Sets whether an error in dependency-check should fail the build.
+     */
+    private boolean failOnError = true;
+
+    /**
      * Sets whether an NVD update should be the only thing performed. If true,
      * a scan will not be performed.
      */
@@ -493,6 +498,16 @@ public class Options implements Serializable {
     public void setAutoUpdate(boolean autoUpdate) {
         this.autoUpdate = autoUpdate;
     }
+
+    /**
+     * Returns whether an error in dependency-check should fail the build. Default is false.
+     */
+    public boolean failOnError() { return failOnError; }
+
+    /**
+     * Sets whether an error in dependency-check should fail the build.
+     */
+    public void setFailOnError(boolean failOnError) { this.failOnError = failOnError; }
 
     /**
      * Returns whether updates should be the only task performed.

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
@@ -61,6 +61,9 @@ limitations under the License.
         <f:entry title="${%upstream.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-upstream-skip.html">
             <f:checkbox id="skipOnUpstreamChange" name="skipOnUpstreamChange" checked="${instance.getSkipOnUpstreamChange()}"/>
         </f:entry>
+        <f:entry title="${%disable.failonerror}" description="" help="/plugin/dependency-check-jenkins-plugin/help-failonerror.html">
+            <f:checkbox id="isFailOnErrorDisabled" name="isFailOnErrorDisabled" checked="${instance.getIsFailOnErrorDisabled()}"/>
+        </f:entry>
     </f:advanced>
 
     <script type="text/javascript">

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
@@ -24,3 +24,4 @@ extensions.zip=ZIP extensions
 disable.autoupdate=Disable NVD auto-update
 scm.skip=Skip if triggered by SCM changes
 upstream.skip=Skip if triggered by upstream changes
+disable.failonerror=Disable marking build as failure due to error during dependency check

--- a/src/main/webapp/help-failonerror.html
+++ b/src/main/webapp/help-failonerror.html
@@ -1,0 +1,3 @@
+<div>
+    If disabled, dependency check will not mark the build as failure due to error.
+</div>


### PR DESCRIPTION
This adds a option so you can disable failing of builds due to any errors during dependency check. This is similar to the option that is available in the maven plugin.

This is useful to have when encountering errors in dependency check, but you don't want to block your dev teams progress by failing all of their builds while you troubleshoot. I also added a stack trace log to help troubleshooting as I encountered NullPointerException(s) with dependency check and in that case it doesn't give you a very good indication to where the problem might be.

An example of the NPE logs:
```
[DependencyCheck] One or more exceptions were thrown while executing Dependency-Check
[DependencyCheck] Exception Caught: java.lang.NullPointerException
[DependencyCheck] Message: null
[DependencyCheck] Exception Caught: java.lang.NullPointerException
[DependencyCheck] Message: null
... [REDACTED FOR BREVITY] ...
Build step 'Invoke OWASP Dependency-Check analysis' changed build result to FAILURE
```
