### PR TITLE
Make inner class of DependencyTrackPublisher serializable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
@@ -61,7 +61,7 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
 
     private final String projectId;
     private final String scanResult;
-    private PrintStream logger;
+    private transient PrintStream logger;
 
     @DataBoundConstructor // Fields in config.jelly must match the parameter names
     public DependencyTrackPublisher(final String projectId, final String scanResult) {
@@ -201,7 +201,9 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
      * for the actual HTML fragment for the configuration screen.
      */
     @Extension @Symbol("dependencyTrackPublisher") // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements Serializable {
+
+        private static final long serialVersionUID = -2018722914973282748L;
 
         /**
          * Specifies the base URL to Dependency-Track v3 or higher.


### PR DESCRIPTION
This is to avoid exception when running pipeline build on a slave. This seems somewhat related to JENKINS-45782, see https://github.com/jenkinsci/dependency-check-plugin/commit/05f7c6b0677d9db91469a876101b3ee0cdb0c1fa.

```
java.io.NotSerializableException: java.io.PrintStream
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at hudson.remoting.UserRequest._serialize(UserRequest.java:245)
	at hudson.remoting.UserRequest.serialize(UserRequest.java:254)
Caused: java.io.IOException: Unable to serialize org.jenkinsci.plugins.DependencyCheck.DependencyTrackPublisher$1@595f5773
	at hudson.remoting.UserRequest.serialize(UserRequest.java:256)
	at hudson.remoting.UserRequest.<init>(UserRequest.java:97)
	at hudson.remoting.Channel.call(Channel.java:894)
	at org.jenkinsci.plugins.DependencyCheck.DependencyTrackPublisher.perform(DependencyTrackPublisher.java:108)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
	at hudson.security.ACL.impersonate(ACL.java:260)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```