### PR TITLE
fix error when the "version" is empty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
@@ -254,7 +254,7 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
                             for (int i = 0; i < array.size(); i++) {
                                 JsonObject jsonObject = array.getJsonObject(i);
                                 String name = jsonObject.getString("name");
-                                String version = jsonObject.getString("version");
+                                String version = jsonObject.getString("version", "null");
                                 String uuid = jsonObject.getString("uuid");
                                 if (StringUtils.isNotBlank(version)) {
                                     name = name + " " + version;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
@@ -256,7 +256,7 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
                                 String name = jsonObject.getString("name");
                                 String version = jsonObject.getString("version", "null");
                                 String uuid = jsonObject.getString("uuid");
-                                if (StringUtils.isNotBlank(version)) {
+                                if (!version.equals("null")) {
                                     name = name + " " + version;
                                 }
                                 projects.add(name, uuid);


### PR DESCRIPTION
When people create a project without add the version, jenkins plugin will run error.
That's because the JsonObject can't do with the empty value.
So there are two ways to solve this problems.
1. the plugin could check the value of "version", and set a default value.
2. the track could check the value is or not empty when people create a new project.