### PR TITLE
Adding option to disable Node Package Analyser

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -277,6 +277,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
 
         // Enable/Disable Analyzers
         options.setJarAnalyzerEnabled(this.getDescriptor().isJarAnalyzerEnabled);
+        options.setNodePackageAnalyzerEnabled(this.getDescriptor().isNodePackageAnalyzerEnabled);
         options.setNspAnalyzerEnabled(this.getDescriptor().isNspAnalyzerEnabled);
         options.setComposerLockAnalyzerEnabled(this.getDescriptor().isComposerLockAnalyzerEnabled);
         options.setPythonDistributionAnalyzerEnabled(this.getDescriptor().isPythonDistributionAnalyzerEnabled);
@@ -415,6 +416,11 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
          * Specifies if the Jar analyzer should be enabled or not
          */
         private boolean isJarAnalyzerEnabled = true;
+
+        /**
+         * Specifies if the Node Package analyzer should be enabled or not
+         */
+        private boolean isNodePackageAnalyzerEnabled = true;
 
         /**
          * Specifies if the NSP analyzer should be enabled or not
@@ -599,6 +605,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
             cveUrl12Base = formData.getString("cveUrl12Base");
             cveUrl20Base = formData.getString("cveUrl20Base");
             isJarAnalyzerEnabled = formData.getBoolean("isJarAnalyzerEnabled");
+            isNodePackageAnalyzerEnabled = formData.getBoolean("isNodePackageAnalyzerEnabled");
             isNspAnalyzerEnabled = formData.getBoolean("isNspAnalyzerEnabled");
             isComposerLockAnalyzerEnabled = formData.getBoolean("isComposerLockAnalyzerEnabled");
             isPythonDistributionAnalyzerEnabled = formData.getBoolean("isPythonDistributionAnalyzerEnabled");
@@ -678,6 +685,13 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
          */
         public boolean getIsJarAnalyzerEnabled() {
             return isJarAnalyzerEnabled;
+        }
+
+        /**
+         * Returns the global configuration for enabling the Node Package analyzer.
+         */
+        public boolean getIsNodePackageAnalyzerEnabled() {
+            return isNodePackageAnalyzerEnabled;
         }
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -242,6 +242,7 @@ class DependencyCheckExecutor extends MasterToSlaveCallable<Boolean, IOException
         settings.setBoolean(Settings.KEYS.ANALYZER_EXPERIMENTAL_ENABLED, true);
 
         settings.setBoolean(Settings.KEYS.ANALYZER_JAR_ENABLED, options.isJarAnalyzerEnabled());
+        settings.setBoolean(Settings.KEYS.ANALYZER_NODE_PACKAGE_ENABLED, options.isNodePackageAnalyzerEnabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_NSP_PACKAGE_ENABLED, options.isNspAnalyzerEnabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_COMPOSER_LOCK_ENABLED, options.isComposerLockAnalyzerEnabled());
         settings.setBoolean(Settings.KEYS.ANALYZER_PYTHON_DISTRIBUTION_ENABLED, options.isPythonDistributionAnalyzerEnabled());

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/Options.java
@@ -177,6 +177,11 @@ public class Options implements Serializable {
     private boolean jarAnalyzerEnabled;
 
     /**
+     * Specifies if the Node Package analyzer is enabled
+     */
+    private boolean nodePackageAnalyzerEnabled;
+
+    /**
      * Specifies if the NSP analyzer is enabled
      */
     private boolean nspAnalyzerEnabled;
@@ -703,6 +708,20 @@ public class Options implements Serializable {
     }
 
     /**
+     * Returns if the Node Package analyzer is enabled or not.
+     */
+    public boolean isNodePackageAnalyzerEnabled() {
+        return nodePackageAnalyzerEnabled;
+    }
+
+    /**
+     * Sets if the NSP analyzer is enabled or not.
+     */
+    public void setNodePackageAnalyzerEnabled(boolean nodePackageAnalyzerEnabled) {
+        this.nodePackageAnalyzerEnabled = nodePackageAnalyzerEnabled;
+    }
+
+    /**
      * Returns if the NSP analyzer is enabled or not.
      */
     public boolean isNspAnalyzerEnabled() {
@@ -1104,6 +1123,7 @@ public class Options implements Serializable {
         sb.append(" -isQuickQueryTimestampEnabled = ").append(isQuickQueryTimestampEnabled).append("\n");
 
         sb.append(" -jarAnalyzerEnabled = ").append(jarAnalyzerEnabled).append("\n");
+        sb.append(" -nodePackageAnalyzerEnabled = ").append(nodePackageAnalyzerEnabled).append("\n");
         sb.append(" -nspAnalyzerEnabled = ").append(nspAnalyzerEnabled).append("\n");
         sb.append(" -composerLockAnalyzerEnabled = ").append(composerLockAnalyzerEnabled).append("\n");
         sb.append(" -pythonDistributionAnalyzerEnabled = ").append(pythonDistributionAnalyzerEnabled).append("\n");

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.jelly
@@ -148,6 +148,10 @@ limitations under the License.
                     <f:checkbox id="composerlock.enabled" name="isComposerLockAnalyzerEnabled" checked="${instance.isComposerLockAnalyzerEnabled}"/>
                 </f:entry>
 
+                <f:entry title="${%nodepackage.enabled}" description="" help="/plugin/dependency-check-jenkins-plugin/help-nodepackage-analyzer-enabled.html">
+                    <f:checkbox id="nodepackage.enabled" name="isNodePackageAnalyzerEnabled" checked="${instance.isNodePackageAnalyzerEnabled}"/>
+                </f:entry>
+
                 <f:entry title="${%nsp.enabled}" description="" help="/plugin/dependency-check-jenkins-plugin/help-nsp-analyzer-enabled.html">
                     <f:checkbox id="nsp.enabled" name="isNspAnalyzerEnabled" checked="${instance.isNspAnalyzerEnabled}"/>
                 </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/global.properties
@@ -35,6 +35,7 @@ bundleaudit.path=Path to Ruby Bundle Audit binary
 temp.path=Temporary directory
 global.data.directory=Global Data Directory
 jar.enabled=Enable JAR analyzer
+nodepackage.enabled=Enable Node Package analyzer
 nsp.enabled=Enable Node Security Platform analyzer
 composerlock.enabled=Enable PHP Composer.lock analyzer
 pythondistribution.enabled=Enable Python distribution analyzer

--- a/src/main/webapp/help-nodepackage-analyzer-enabled.html
+++ b/src/main/webapp/help-nodepackage-analyzer-enabled.html
@@ -1,0 +1,7 @@
+<div>
+    If enabled, Dependency-Check will analyze Node Package Manager (npm) package.json
+    files, and collect information that can be used to determine the associated CPE.
+    This analyser depends on NSP Analyser.
+    This analyzer requires Internet access along with a Java runtime compatible with
+    the TLS version and cipher specifications used by the Node Security Platform API.
+</div>


### PR DESCRIPTION
It's impossible now to disable this analyser in the global config.
If I disable NSP analyser, I then have an error  "Message: Invalid Configuration: enabling the Node Package Analyzer without using the NSP Analyzer is not supported."

So it's impossible to perform a dependency check analysis without NSP Analyser activated.

So this pull request adds an option to activate or not the Node Package Analyser.