### PR TITLE
Ensure Temporary Files Deleted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckExecutor.java
@@ -122,10 +122,10 @@ class DependencyCheckExecutor extends MasterToSlaveCallable<Boolean, IOException
                 log(ExceptionUtils.getStackTrace(t));
             }
         } finally {
-            settings.cleanup(true);
             if (engine != null) {
                 engine.close();
             }
+            settings.cleanup(true);
         }
         return false;
     }


### PR DESCRIPTION
@stevespringett Due to changes in how the local H2 database is handled one must close the database (and any open connections) prior to closing the settings. This will ensure that the temp directory can be removed.

Additionally, if we upped the Java source version to 1.7 we could use a try with resources for the engine object.