### PR TITLE
Do not try to upload file if artifact is blank

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyTrackPublisher.java
@@ -137,7 +137,7 @@ public class DependencyTrackPublisher extends Recorder implements SimpleBuildSte
         final FilePath filePath = new FilePath(workspace, artifact);
         final String encodedScan;
         try {
-            if (!filePath.exists()) {
+            if (StringUtils.isBlank(artifact) || !filePath.exists()) {
                 log(Messages.DtrackBuilder_Result_NonExist());
                 return false;
             }


### PR DESCRIPTION
When no artifact is specified, an empty body is uploaded and the build succeeds without an error/hint.