### PR TITLE
Preserve build result state regardless scan success

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractDependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractDependencyCheckBuilder.java
@@ -43,8 +43,9 @@ public abstract class AbstractDependencyCheckBuilder extends Builder implements 
 
     private static final String OUT_TAG = "[" + DependencyCheckPlugin.PLUGIN_NAME + "] ";
 
-    boolean skipOnScmChange;
-    boolean skipOnUpstreamChange;
+    protected boolean skipOnScmChange;
+    protected boolean skipOnUpstreamChange;
+    protected boolean preserveBuildSuccessOnScanFailure;
     private Options options;
 
 
@@ -86,7 +87,7 @@ public abstract class AbstractDependencyCheckBuilder extends Builder implements 
         } else {
             success = launcher.getChannel().call(new DependencyCheckExecutor(options, listener));
         }
-        if (success) {
+        if (success || preserveBuildSuccessOnScanFailure) {
             build.setResult(Result.SUCCESS);
         } else {
             build.setResult(Result.FAILURE);

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -67,7 +67,8 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
     public DependencyCheckBuilder(String scanpath, String outdir, String datadir, String suppressionFile,
 				  String hintsFile, String zipExtensions, Boolean isAutoupdateDisabled,
 				  Boolean includeHtmlReports, Boolean includeVulnReports, Boolean includeJsonReports,
-                  Boolean includeCsvReports, Boolean skipOnScmChange, Boolean skipOnUpstreamChange) {
+                  Boolean includeCsvReports, Boolean skipOnScmChange, Boolean skipOnUpstreamChange,
+                  Boolean preserveBuildSuccessOnScanFailure) {
         this.scanpath = scanpath;
         this.outdir = outdir;
         this.datadir = datadir;
@@ -81,6 +82,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
         this.includeCsvReports = (includeCsvReports != null) && includeCsvReports;
         this.skipOnScmChange = (skipOnScmChange != null) && skipOnScmChange;
         this.skipOnUpstreamChange = (skipOnUpstreamChange != null) && skipOnUpstreamChange;
+        this.preserveBuildSuccessOnScanFailure = (preserveBuildSuccessOnScanFailure != null) && preserveBuildSuccessOnScanFailure;;
     }
 
     /**
@@ -190,6 +192,15 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
      */
     public boolean getSkipOnUpstreamChange() {
         return skipOnUpstreamChange;
+    }
+
+    /**
+     * Retrieves whether build result should set to failure on core execution failure or not.
+     * This is a per-build config item.
+     * This method must match the value in <tt>config.jelly</tt>.
+     */
+    public boolean getPreserveBuildSuccessOnScanFailure() {
+        return preserveBuildSuccessOnScanFailure;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder.java
@@ -82,7 +82,7 @@ public class DependencyCheckBuilder extends AbstractDependencyCheckBuilder {
         this.includeCsvReports = (includeCsvReports != null) && includeCsvReports;
         this.skipOnScmChange = (skipOnScmChange != null) && skipOnScmChange;
         this.skipOnUpstreamChange = (skipOnUpstreamChange != null) && skipOnUpstreamChange;
-        this.preserveBuildSuccessOnScanFailure = (preserveBuildSuccessOnScanFailure != null) && preserveBuildSuccessOnScanFailure;;
+        this.preserveBuildSuccessOnScanFailure = (preserveBuildSuccessOnScanFailure != null) && preserveBuildSuccessOnScanFailure;
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.jelly
@@ -64,6 +64,9 @@ limitations under the License.
         <f:entry title="${%upstream.skip}" description="" help="/plugin/dependency-check-jenkins-plugin/help-upstream-skip.html">
             <f:checkbox id="skipOnUpstreamChange" name="skipOnUpstreamChange" checked="${instance.getSkipOnUpstreamChange()}"/>
         </f:entry>
+        <f:entry title="${%buildResult.preserve}" description="" help="/plugin/dependency-check-jenkins-plugin/help-buildResultSuccess-preserve.html">
+            <f:checkbox id="preserveBuildSuccessOnScanFailure" name="preserveBuildSuccessOnScanFailure" checked="${instance.getPreserveBuildSuccessOnScanFailure()}"/>
+        </f:entry>
     </f:advanced>
 
     <script type="text/javascript">

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckBuilder/config.properties
@@ -25,3 +25,4 @@ extensions.zip=ZIP extensions
 disable.autoupdate=Disable NVD auto-update
 scm.skip=Skip if triggered by SCM changes
 upstream.skip=Skip if triggered by upstream changes
+buildResult.preserve=Preserve build result as success regardless of scan result

--- a/src/main/webapp/help-buildResultSuccess-preserve.html
+++ b/src/main/webapp/help-buildResultSuccess-preserve.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, a Dependency-Check analysis result will not be affect build result.
+</div>


### PR DESCRIPTION
Dependency-Check core used to fail by different reasons: DB misconfiguration, internal bugs, locks etc...
If ODC check is executed in pipeline and it is optional check then we are not intrested in affecting pipeline result. 
Although we could catch and handle all ODC exceptions, we cannot improve build result during handling without using unsecure things as _currentBuild.rawBuild_.

This feature allow to preserve previous state of build in case of scan failure. It wiil be very usefull in companies where pipelines are not single-stage pipelines.
