### PR TITLE
fix attempt to serialize anonymous class (JEP-200)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstallation.java
@@ -68,14 +68,25 @@ public class DependencyCheckInstallation extends ToolInstallation
 
     public String getExecutable(@Nonnull Launcher launcher) throws IOException, InterruptedException {
         final VirtualChannel channel = launcher.getChannel();
-        return channel == null ? null : channel.call(new MasterToSlaveCallable<String, IOException>() {
-            @Override
-            public String call() throws IOException {
-                final String arch = ((String) System.getProperties().get("os.name")).toLowerCase(Locale.ENGLISH);
-                final String command = (arch.contains("windows")) ? "dependency-check.bat" : "dependency-check.sh";
-                return getHome() + File.separator + "bin" + File.separator + command;
-            }
-        });
+        return channel == null ? null : channel.call(new FindExecutableCallable(getHome()));
+    }
+
+    private static class FindExecutableCallable extends MasterToSlaveCallable<String, IOException> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String home;
+
+        FindExecutableCallable(String home) {
+            this.home = home;
+        }
+
+        @Override
+        public String call() throws IOException {
+            final String arch = ((String) System.getProperties().get("os.name")).toLowerCase(Locale.ENGLISH);
+            final String command = (arch.contains("windows")) ? "dependency-check.bat" : "dependency-check.sh";
+            return home + File.separator + "bin" + File.separator + command;
+        }
     }
 
     @Extension


### PR DESCRIPTION
This PR fixes this warning (seen first time one runs a job using a DependencyCheck installation):

```
2020-01-28 13:04:31.960+0000 [id=68]	WARNING	o.j.r.u.AnonymousClassWarnings#warn: Attempt to (de-)serialize anonymous class org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstallation$1 in file:/var/lib/jenkins/plugins/dependency-check-jenkins-plugin/WEB-INF/lib/dependency-check-jenkins-plugin.jar; see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```

See https://jenkins.io/redirect/serialization-of-anonymous-classes/ for explanations. I think my patch is pretty obvious, and I've tested that the warning goes away with patched version of the plugin.