### PR TITLE
fix ResultAction serialization (JENKINS-45892)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
@@ -25,8 +25,8 @@ import org.jenkinsci.plugins.DependencyCheck.model.Finding;
 import org.jenkinsci.plugins.DependencyCheck.model.SeverityDistribution;
 import org.jenkinsci.plugins.DependencyCheck.transformer.FindingsTransformer;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,18 +37,13 @@ import java.util.List;
  */
 public class ResultAction implements RunAction2, SimpleBuildStep.LastBuildAction {
 
-    private Run<?, ?> run;
+    private transient Run<?, ?> run; // transient: see RunAction2, and JENKINS-45892
     private List<Finding> findings;
     private SeverityDistribution severityDistribution;
-    private List<JobAction> projectActions;
 
     public ResultAction(Run<?, ?> build, List<Finding> findings, SeverityDistribution severityDistribution) {
         this.findings = findings;
         this.severityDistribution = severityDistribution;
-
-        List<JobAction> projectActions = new ArrayList<>();
-        projectActions.add(new JobAction(build.getParent()));
-        this.projectActions = projectActions;
     }
 
     @Override
@@ -78,7 +73,7 @@ public class ResultAction implements RunAction2, SimpleBuildStep.LastBuildAction
 
     @Override
     public Collection<? extends Action> getProjectActions() {
-        return this.projectActions;
+        return Collections.singleton(new JobAction(run.getParent()));
     }
 
     public Run getRun() {


### PR DESCRIPTION
Fixes this warning (when using the `DependencyCheckPublisher`):

```
2020-01-28 14:10:01.010+0000 [id=46]	WARNING	hudson.XmlFile#replaceIfNotAtTopLevel: JENKINS-45892: reference to hudson.model.FreeStyleProject@1fac1ebf[test-js] being saved from unexpected /var/lib/jenkins/jobs/test-js/builds/12/build.xml
```

This comes from changes introduced in 5.1.0 on `ResultAction`: 8a7497b

- the reference to the `Run` has been made non-transient, whereas it was correct to have it as a transient field (you don't want to serialize / self-reference the `Run` itself in the `build.xml`). The [RunAction2](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/RunAction2.java) interface is implemented, and it takes care of having a reference to the Run injected via `onLoad()` when the action is deserialized.

- implementing [SimpleBuildStep.LastBuildAction](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/tasks/SimpleBuildStep.java#L88) was the right fix for [JENKINS-58381](https://issues.jenkins-ci.org/browse/JENKINS-58381) (from my understanding), but its `getProjectActions()` method is meant to return *transient* `Action`s for the parent job, whereas here the `List<JobAction>` it returns has also been added as a non-transient field (introducing a non-transient relation from `ResultAction` to the `Job` itself).

So, this fixes that. I've tested that the trend graphs are still correctly displayed, both for Freestyle and Pipeline jobs (and also after Jenkins has been restarted).

Note that, with these changes, Jenkins will complain about unknown data in `build.xml` files from version 5.1.0 (*/administrativeMonitor/OldData/manage* will show some `MissingFieldException: No field 'projectActions' found in class 'org.jenkinsci.plugins.DependencyCheck.ResultAction'` warnings).  [It can be fixed](https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility) by keeping the `projectActions` field around and simply making it transient, but I don't know, I find it weird to keep dead code like that simply to hide an old-data warning. Let me know if you prefer me to do that.