### PR TITLE
Fix build status indication in blue ocean build step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
@@ -34,6 +34,7 @@ import org.jenkinsci.plugins.DependencyCheck.model.ReportParser;
 import org.jenkinsci.plugins.DependencyCheck.model.ReportParserException;
 import org.jenkinsci.plugins.DependencyCheck.model.RiskGate;
 import org.jenkinsci.plugins.DependencyCheck.model.SeverityDistribution;
+import org.jenkinsci.plugins.DependencyCheck.model.ThresholdsExceededException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import javax.annotation.Nonnull;
@@ -147,6 +148,9 @@ public class DependencyCheckPublisher extends ThresholdCapablePublisher implemen
         if (Result.SUCCESS != result) {
             logger.log(Messages.Publisher_Threshold_Exceed());
             build.setResult(result); // only set the result if the evaluation fails the threshold
+        }
+        if (Result.FAILURE == result) {
+            throw new ThresholdsExceededException(Messages.Publisher_Threshold_Exceed());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ThresholdsExceededException.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ThresholdsExceededException.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.plugins.DependencyCheck.model;
+
+/**
+ * Exception used to indicate that the defined thresholds are exceeded. This
+ * causes the build step and also the build to fail.
+ */
+public class ThresholdsExceededException extends RuntimeException {
+    public ThresholdsExceededException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Because the call "build.setResult()" does only affect the overall build
status and not the build step status, the status on the build step was
previously not displayed correctly. By throwing an exception in case the
Thresholds are exceeded, the build step status correctly shows the failure.

If the build step status is not correctly shown, it's sometimes hard to
find the reason for a build failure, specially if there are many build steps.

Before:
![screenshot_before](https://user-images.githubusercontent.com/5829661/137593873-711d4009-4fad-4867-ac71-0336757c7dc2.png)

After my change:
![screenshot_after](https://user-images.githubusercontent.com/5829661/137593880-de46813f-5504-4927-8e63-1fe94d31161b.png)


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
