### PR TITLE
Ignore files that are downloaded during the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 .project
 .settings/
 .factorypath
+
+# Ignore files that are downloaded during the build
+src/main/webapp/js/libs/echarts.common.min.js
+src/main/webapp/js/libs/footable.min.js
+src/main/webapp/js/libs/jquery.min.js
+src/main/webapp/js/libs/jquery.min.map


### PR DESCRIPTION
Add the files that are downloaded as part of the build process to the `.gitignore` file so they don't need to be excluded manually from commits.