### PR TITLE
[JENKINS-67870] Add project action Latest Dependency-Check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
@@ -73,7 +73,11 @@ public class ResultAction implements RunAction2, SimpleBuildStep.LastBuildAction
 
     @Override
     public Collection<? extends Action> getProjectActions() {
-        return Collections.singleton(new JobAction(run.getParent()));
+        if (!run.getActions(ResultProjectAction.class).isEmpty()) {
+            // someone already added one
+            return Collections.emptySet();
+        }
+        return Collections.singleton(new ResultProjectAction(run.getParent()));
     }
 
     public Run getRun() {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultProjectAction.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Dependency-Check Jenkins plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.DependencyCheck;
+
+import hudson.model.Action;
+import hudson.model.Job;
+
+/**
+ * Action attached to project to link latest dependency-check report.
+ *
+ * @author Nikolas Falco
+ * @since 5.1.3
+ */
+public class ResultProjectAction implements Action {
+
+    /**
+     * Project that owns this action.
+     */
+    public final Job<?,?> job;
+
+    public ResultProjectAction(Job<?,?> job) {
+        this.job = job;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Dependency-Check";
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/ResultProjectAction/jobMain.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/ResultProjectAction/jobMain.jelly
@@ -1,0 +1,28 @@
+<!--
+This file is part of Dependency-Check Jenkins plugin.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test">
+    <table style="margin-top: 1em; margin-left: 1em;">
+        <j:set var="tr" value="${it.job.lastCompletedBuild.getAction(it.class.classLoader.loadClass('org.jenkinsci.plugins.DependencyCheck.ResultAction'))}"/>
+        <j:if test="${tr != null}">
+            <t:summary icon="/plugin/dependency-check-jenkins-plugin/icons/dependency-check-icon.svg">
+                <a href="lastCompletedBuild/${tr.urlName}/">${%Latest Dependency-Check}</a>
+                <st:nbsp/>
+                <test:test-result it="${tr}"/>
+            </t:summary>
+        </j:if>
+    </table>
+</j:jelly>


### PR DESCRIPTION
To improve accessibility to the latest dependency check report add a new action on the main job page as for the "Last Test Result" that leads to the last dependency-check.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

![immagine](https://user-images.githubusercontent.com/4160180/155126101-bcde41f2-ccc1-4188-8bf8-28011e7951aa.png)
