### PR TITLE
give the correct (reversed) priority to the drawn chart lines

### DIFF
--- a/src/main/webapp/js/charts.js
+++ b/src/main/webapp/js/charts.js
@@ -61,19 +61,9 @@ function renderOwaspTrendChart(chartDivId, chartModel) {
         color: ['#dc0000', '#fd8c00', '#fdc500', '#4cae4c', '#c0c0c0'],
         series : [
             {
-                name: 'Critical',
+                name: 'Unassigned',
                 type: 'line',
-                data: critical
-            },
-            {
-                name: 'High',
-                type: 'line',
-                data: high
-            },
-            {
-                name: 'Medium',
-                type: 'line',
-                data: medium
+                data: unassigned
             },
             {
                 name: 'Low',
@@ -81,9 +71,19 @@ function renderOwaspTrendChart(chartDivId, chartModel) {
                 data: low
             },
             {
-                name: 'Unassigned',
+                name: 'Medium',
                 type: 'line',
-                data: unassigned
+                data: medium
+            },
+            {
+                name: 'High',
+                type: 'line',
+                data: high
+            },
+            {
+                name: 'Critical',
+                type: 'line',
+                data: critical
             }
         ]
     };


### PR DESCRIPTION
it seems that echarts gives the highest priority to the series defined last. So if we want critical vulnerabilities to be seen, even if there are lower ranking vulnerabilities with the same occurrence, then we need to define the critical series last.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
