### PR TITLE
JENKINS-68342: Compare findings against last build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV2.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV2.java
@@ -16,6 +16,7 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Java Bean class for CVSSv2 identified by DependencyCheck.
@@ -98,5 +99,20 @@ public class CvssV2 implements Serializable {
 
     public void setSeverity(String severity) {
         this.severity = severity;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CvssV2 cvssV2 = (CvssV2) o;
+        return Objects.equals(score, cvssV2.score) && Objects.equals(accessVector, cvssV2.accessVector) && Objects.equals(accessComplexity, cvssV2.accessComplexity) && Objects.equals(authenticationr, cvssV2.authenticationr) && Objects.equals(confidentialImpact, cvssV2.confidentialImpact) && Objects.equals(integrityImpact, cvssV2.integrityImpact) && Objects.equals(availabilityImpact, cvssV2.availabilityImpact) && Objects.equals(severity, cvssV2.severity);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(score, accessVector, accessComplexity, authenticationr, confidentialImpact, integrityImpact, availabilityImpact, severity);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV3.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV3.java
@@ -16,6 +16,7 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Java Bean class for CVSSv3 identified by DependencyCheck.
@@ -116,5 +117,20 @@ public class CvssV3 implements Serializable {
 
     public void setBaseSeverity(String baseSeverity) {
         this.baseSeverity = baseSeverity;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CvssV3 cvssV3 = (CvssV3) o;
+        return Objects.equals(baseScore, cvssV3.baseScore) && Objects.equals(attackVector, cvssV3.attackVector) && Objects.equals(attackComplexity, cvssV3.attackComplexity) && Objects.equals(privilegesRequired, cvssV3.privilegesRequired) && Objects.equals(userInteraction, cvssV3.userInteraction) && Objects.equals(scope, cvssV3.scope) && Objects.equals(confidentialityImpact, cvssV3.confidentialityImpact) && Objects.equals(integrityImpact, cvssV3.integrityImpact) && Objects.equals(availabilityImpact, cvssV3.availabilityImpact) && Objects.equals(baseSeverity, cvssV3.baseSeverity);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(baseScore, attackVector, attackComplexity, privilegesRequired, userInteraction, scope, confidentialityImpact, integrityImpact, availabilityImpact, baseSeverity);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
@@ -17,7 +17,9 @@ package org.jenkinsci.plugins.DependencyCheck.model;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Java Bean class for a Dependency found by DependencyCheck.
@@ -104,5 +106,20 @@ public class Dependency implements Serializable {
 
     public void addVulnerability(Vulnerability vulnerability) {
         vulnerabilities.add(vulnerability);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Dependency that = (Dependency) o;
+        return Objects.equals(fileName, that.fileName) && Objects.equals(filePath, that.filePath) && Objects.equals(description, that.description) && Objects.equals(license, that.license) && Objects.equals(new HashSet<>(vulnerabilities), new HashSet<>(that.vulnerabilities));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(fileName, filePath, description, license, vulnerabilities);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Finding.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Finding.java
@@ -16,6 +16,7 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Java Bean class for Findings which represent a single pair of Dependency + Vulnerability.
@@ -41,5 +42,20 @@ public class Finding implements Serializable {
 
     public Vulnerability getVulnerability() {
         return vulnerability;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Finding finding = (Finding) o;
+        return Objects.equals(dependency, finding.dependency) && Objects.equals(vulnerability, finding.vulnerability);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(dependency, vulnerability);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Reference.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Reference.java
@@ -16,6 +16,7 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Java Bean class for Reference found by DependencyCheck.
@@ -53,5 +54,20 @@ public class Reference implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Reference reference = (Reference) o;
+        return Objects.equals(source, reference.source) && Objects.equals(url, reference.url) && Objects.equals(name, reference.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(source, url, name);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Vulnerability.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Vulnerability.java
@@ -18,6 +18,7 @@ package org.jenkinsci.plugins.DependencyCheck.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Java Bean class for Vulnerability found by DependencyCheck.
@@ -116,5 +117,20 @@ public class Vulnerability implements Serializable {
 
     public void addReference(Reference reference) {
         references.add(reference);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Vulnerability that = (Vulnerability) o;
+        return source == that.source && Objects.equals(name, that.name) && Objects.equals(severity, that.severity) && Objects.equals(cvssV2, that.cvssV2) && Objects.equals(cvssV3, that.cvssV3) && Objects.equals(cwes, that.cwes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(source, name, severity, cvssV2, cvssV3, cwes);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/ResultAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/ResultAction/index.jelly
@@ -45,19 +45,43 @@ limitations under the License.
                    data-sorting="true" data-editing="false" data-state="true">
             </table>
 
+            <h2>Findings introduced in this build</h2>
+            <table id="newFindings-table" class="table" data-paging="true" data-filtering="true"
+                   data-sorting="true" data-editing="false" data-state="true">
+            </table>
+
+            <h2>Findings of previous build, no longer present in this build</h2>
+            <table id="fixedFindings-table" class="table" data-paging="true" data-filtering="true"
+                   data-sorting="true" data-editing="false" data-state="true">
+            </table>
+
+
             <script>
                 var view = <st:bind value="${it}"/>
                 view.getFindingsJson(function (data) {
-                (function ($) {
-                jQuery.noConflict();
-                $('.table').footable(data.responseJSON);
-                })(jQuery);
+                    (function ($) {
+                        jQuery.noConflict();
+                        $('#findings-table').footable(data.responseJSON);
+                    })(jQuery);
+                });
+
+                view.getFixedFindingsJson(function (data) {
+                    (function ($) {
+                        jQuery.noConflict();
+                        $('#fixedFindings-table').footable(data.responseJSON);
+                    })(jQuery);
+                });
+
+                view.getNewFindingsJson(function (data) {
+                    (function ($) {
+                        jQuery.noConflict();
+                        $('#newFindings-table').footable(data.responseJSON);
+                    })(jQuery);
                 });
 
                 view.getSeverityDistributionJson(function (data) {
-                var json = data.responseJSON;
-                generateSeverityDistributionBar("severity-distribution", "Severity Distribution",
-                json.critical, json.high, json.medium, json.low, json.info, json.unassigned);
+                    var json = data.responseJSON;
+                    generateSeverityDistributionBar("severity-distribution", "Severity Distribution", json.critical, json.high, json.medium, json.low, json.info, json.unassigned);
                 });
             </script>
 

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParserTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -13,5 +15,14 @@ public class ReportParserTest {
         new ReportParser(1).parse(getClass().getResourceAsStream("dependency-check-report-external-entities.xml"));
 
         fail("Should have rejected input with external entities");
+    }
+
+    @Test
+    public void testEqualFindings() throws Exception
+    {
+        final List<Finding> findings1 = new ReportParser(1).parse(getClass().getResourceAsStream("/org/jenkinsci/plugins/DependencyCheck/parser/dependency-check-report.xml"));
+        final List<Finding> findings2 = new ReportParser(2).parse(getClass().getResourceAsStream("/org/jenkinsci/plugins/DependencyCheck/parser/dependency-check-report.xml"));
+
+        assertEquals(findings1, findings2);
     }
 }


### PR DESCRIPTION
This commit adds two new tables to the "Dependency-Check Results" page for each build:
1. all findings that are new in this build.
2. findings that appear to have been fixed (present in the previous build, but not this build).

The implementation depends on comparing Finding instances from the previous build with those
from the current build. To do so, `equals()` and `hashCode()` implementations have been added
to classes that compose the `Finding` class, which is the majority of changes introduced in
this commit. A unit test has been added to verify this behavior.

Two new endpoints have been added that calculate the deltas at runtime. Each of these endpoints
are used by a corresponding new table that is added to the `ResultAction` Jelly view.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

