### PR TITLE
Fixed bug when having multiple installations, the configured version is not selected in the UI

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilder/config.jelly
@@ -18,7 +18,7 @@ limitations under the License.
     <f:entry title="${%installation.title}" description="${%installation.description}">
         <select class="setting-input" name="_.odcInstallation">
             <j:forEach var="inst" items="${descriptor.installations}">
-                <f:option selected="${inst.name==instance.nodeJSInstallationName}">${inst.name}</f:option>
+                <f:option selected="${inst.name==instance.odcInstallation}">${inst.name}</f:option>
             </j:forEach>
         </select>
     </f:entry>


### PR DESCRIPTION
Fixed bug when having multiple installations, the configured version is not selected in the UI.

As reported in [JENKINS-71670](https://issues.jenkins.io/browse/JENKINS-71670), when there are multiple installations of dependency-check available, the configured one is not selected when loading a job in the UI. Because none is selected, the drop-down defaults to selecting the first entry, which might update the job-configuration on save, if it was not the correct selection.

Bug appeared to be a copy-paste issue, where a field-name wasn't changed.

### Testing done

Change was tested manually by having installed 2 versions of DC:
- Create a job, add a DC-run and select the 2nd installation. Save
- Edit the job: before this update, the selected installation shows the 1st, after the fix it shows the 2nd.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
