### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(jdkVersions: [11])
+buildPlugin(jdkVersions: [21, 17])

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
         <revision>5.4.4</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/dependency-check-plugin</gitHubRepo>
-        <jenkins.version>2.375.1</jenkins.version>
-        <jenkins-plugins-bom.artifactId>bom-2.375.x</jenkins-plugins-bom.artifactId>
-        <jenkins-plugins-bom.version>2198.v39c76fc308ca</jenkins-plugins-bom.version>
+        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins-plugins-bom.artifactId>bom-2.387.x</jenkins-plugins-bom.artifactId>
+        <jenkins-plugins-bom.version>2507.vcb_18c56b_f57c</jenkins-plugins-bom.version>
 
         <assertj.version>3.24.2</assertj.version>
         <checkstyle.version>10.12.3</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.65</version>
+        <version>4.73</version>
     </parent>
     <artifactId>dependency-check-jenkins-plugin</artifactId>
     <name>OWASP Dependency-Check Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -134,15 +134,18 @@
             <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Mockito must precede assertj until assertj releases a Java 21 compatible version -->
+        <!-- Restore ordering once assertj supports Java 21 -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Assertj must follow mockito until assertj releases a Java 21 compatible version -->
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.73</version>
+        <version>4.74</version>
     </parent>
     <artifactId>dependency-check-jenkins-plugin</artifactId>
     <name>OWASP Dependency-Check Plugin</name>


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Require Jenkins 2.387.3 and latest bom release

Load mockito-core before assertj-core for Java 21 tests

Includes pull request:

* #104

### Testing done

Confirmed tests pass with Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
