### PR TITLE
Add the ability to ignore missing check results on publish

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
@@ -63,6 +63,7 @@ public class DependencyCheckPublisher extends AbstractThresholdPublisher impleme
 
     private String pattern;
     private boolean stopBuild = false;
+    private boolean ignoreNoResults = false;
 
     @DataBoundConstructor
     public DependencyCheckPublisher() {
@@ -94,6 +95,15 @@ public class DependencyCheckPublisher extends AbstractThresholdPublisher impleme
 
     public boolean isStopBuild() {
         return stopBuild;
+    }
+
+    public boolean isIgnoreNoResults() {
+        return ignoreNoResults;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreNoResults(boolean ignoreNoResults) {
+        this.ignoreNoResults = ignoreNoResults;
     }
 
     /**
@@ -136,6 +146,9 @@ public class DependencyCheckPublisher extends AbstractThresholdPublisher impleme
         final FilePath[] odcReportFiles = filePath.list(pattern);
         if (ArrayUtils.isEmpty(odcReportFiles)) {
             logger.println(Messages.Publisher_NoArtifactsFound());
+            if (ignoreNoResults) {
+                return result;
+            }
             return Result.UNSTABLE;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStep.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStep.java
@@ -40,6 +40,7 @@ public class DependencyCheckStep extends Step implements Serializable {
 
     private String pattern;
     private boolean stopBuild = false;
+    private boolean ignoreNoResults = false;
     private Integer unstableTotalCritical;
     private Integer unstableTotalHigh;
     private Integer unstableTotalMedium;
@@ -90,6 +91,15 @@ public class DependencyCheckStep extends Step implements Serializable {
 
     public boolean isStopBuild() {
         return stopBuild;
+    }
+
+    public boolean isIgnoreNoResults() {
+        return ignoreNoResults;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreNoResults(boolean ignoreNoResults) {
+        this.ignoreNoResults = ignoreNoResults;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepExecutor.java
@@ -53,6 +53,7 @@ public class DependencyCheckStepExecutor extends SynchronousNonBlockingStepExecu
         DependencyCheckPublisher publisher = new DependencyCheckPublisher();
         publisher.setPattern(step.getPattern());
         publisher.setStopBuild(step.isStopBuild());
+        publisher.setIgnoreNoResults(step.isIgnoreNoResults());
 
         publisher.setTotalThresholdAnalysisExploitable(step.isTotalThresholdAnalysisExploitable());
         publisher.setFailedTotalCritical(step.getFailedTotalCritical());

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/config.jelly
@@ -24,6 +24,10 @@ limitations under the License.
         <f:checkbox checked="${instance.isStopBuild()}" default="false" />
     </f:entry>
 
+    <f:entry title="${%ignoreNoResults.title}" field="ignoreNoResults">
+        <f:checkbox checked="${instance.isIgnoreNoResults()}" default="false" />
+    </f:entry>
+
     <f:advanced title="Risk Gate Thresholds" align="left">
         <f:section title="Risk Gate Thresholds">
             <f:entry title="${%Total Findings}" help="/plugin/dependency-check-jenkins-plugin/help-thresholds-total.html">

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/config.properties
@@ -15,3 +15,4 @@
 
 pattern.title=XML Report Pattern
 stopBuild.title=Stop build when a failed threshold is violated
+ignoreNoResults.title=Ignore missing report files

--- a/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/help-ignoreNoResults.html
+++ b/src/main/resources/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher/help-ignoreNoResults.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, the build will not be marked as unstable if no results are found
+</div>

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepTest.java
@@ -104,4 +104,22 @@ public class DependencyCheckStepTest {
         assertThat(result.getSeverityDistribution().getHigh()).isPositive();
     }
 
+    @Test
+    public void checkIgnoreNoResults() throws Exception {
+        WorkflowJob job = getBaseJob("dependencyCheckPublisherWorkflowStepIgnoreMissing");
+        job.setDefinition(
+            new CpsFlowDefinition("" + "node {\n" + "  dependencyCheckPublisher(pattern: '**/definetlynothere.xml', ignoreNoResults:false)\n"
+                + "  echo('Hello World')\n" + "}\n", true));
+
+        WorkflowRun run = job.scheduleBuild2(0).get();
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, run);
+
+        job = getBaseJob("dependencyCheckPublisherWorkflowStepIgnoreMissing2");
+        job.setDefinition(
+            new CpsFlowDefinition("" + "node {\n" + "  dependencyCheckPublisher(pattern: '**/definetlynothere.xml', ignoreNoResults:true)\n"
+                + "  echo('Hello World')\n" + "}\n", true));
+
+        run = job.scheduleBuild2(0).get();
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, run);
+    }
 }


### PR DESCRIPTION
This patch adds the ability to simply ignore missing report files during the publishing. This can help, if your pipeline does not create them but the publishing part is mandatory in the jenkins library used for the builds.

### Testing done

This patch is used in our jenkins instance for more than a year now providing a seamless workflow with our jenkins libary used.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
