### PR TITLE
JENKINS-74934: Display project references in OWASP dependency check table

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
@@ -38,6 +38,7 @@ public class Dependency implements Serializable {
     private String description;
     private String license;
     private List<Vulnerability> vulnerabilities = new ArrayList<>();
+    private List<String> projectReferences = new ArrayList<>();
 
     public String getFileName() {
         return fileName;
@@ -105,6 +106,18 @@ public class Dependency implements Serializable {
 
     public void addVulnerability(Vulnerability vulnerability) {
         vulnerabilities.add(vulnerability);
+    }
+
+    public List<String> getProjectReferences() {
+        return projectReferences;
+    }
+
+    public void setProjectReferences(List<String> projectReferences) {
+        this.projectReferences = projectReferences;
+    }
+
+    public void addProjectReference(String projectReference) {
+        this.projectReferences.add(projectReference);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParser.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParser.java
@@ -77,6 +77,11 @@ public final class ReportParser {
             digester.addBeanPropertySetter(depXpath + "/description");
             digester.addBeanPropertySetter(depXpath + "/license");
 
+            final String projRefsPath = "analysis/dependencies/dependency/projectReferences";
+            digester.addObjectCreate(projRefsPath, ArrayList.class);
+            digester.addCallMethod(projRefsPath + "/projectReference", "add", 1);
+            digester.addCallParam(projRefsPath + "/projectReference", 0);
+
             final String vulnXpath = "analysis/dependencies/dependency/vulnerabilities/vulnerability";
             digester.addFactoryCreate(vulnXpath, new VulnerabilityCreationFactory());
             digester.addBeanPropertySetter(vulnXpath + "/name");
@@ -126,6 +131,7 @@ public final class ReportParser {
             digester.addSetNext(vulnXpath, "addVulnerability");
             digester.addSetNext(cwesXpath, "setCwes");
             digester.addSetNext(depXpath, "addDependency");
+            digester.addSetNext(projRefsPath, "setProjectReferences");
 
             final Analysis analysis = digester.parse(file);
             if (analysis == null) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
@@ -23,7 +23,6 @@ import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.jenkins.ui.symbol.Symbol;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.transformer;
 
+import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
@@ -22,6 +23,7 @@ import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.jenkins.ui.symbol.Symbol;
@@ -133,7 +135,7 @@ public class FindingsTransformer {
 
         final JSONObject projReferences = new JSONObject();
         projReferences.put("name", "dependency.projectReferences");
-        projReferences.put("title", "Project References");
+        projReferences.put("title", "Referenced In Projects/Scopes");
         projReferences.put("breakpoints", "all");
         projReferences.put("visible", true);
         projReferences.put("filterable", true);
@@ -152,7 +154,9 @@ public class FindingsTransformer {
             row.put("dependency.sha1", escape(dependency.getSha1()));
             row.put("dependency.sha256", escape(dependency.getSha256()));
             if (CollectionUtils.isNotEmpty(dependency.getProjectReferences())) {
-                row.put("dependency.projectReferences", escape(String.join(", ", dependency.getProjectReferences())));
+                row.put("dependency.projectReferences", dependency.getProjectReferences().stream()
+                        .map(s -> "<li>" + escape(s) + "</li>")
+                        .collect(joining("", "<ul>", "</ul>")));
             }
             row.put("vulnerability.source", vulnerability.getSource());
             row.put("vulnerability.name", escape(vulnerability.getName()));

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
@@ -131,6 +131,14 @@ public class FindingsTransformer {
         vulnReferences.put("filterable", false);
         columns.add(vulnReferences);
 
+        final JSONObject projReferences = new JSONObject();
+        projReferences.put("name", "dependency.projectReferences");
+        projReferences.put("title", "Project References");
+        projReferences.put("breakpoints", "all");
+        projReferences.put("visible", true);
+        projReferences.put("filterable", true);
+        columns.add(projReferences);
+
         final JSONArray rows = new JSONArray();
         for (Finding finding: findings) {
             final Dependency dependency = finding.getDependency();
@@ -143,6 +151,9 @@ public class FindingsTransformer {
             row.put("dependency.md5", escape(dependency.getMd5()));
             row.put("dependency.sha1", escape(dependency.getSha1()));
             row.put("dependency.sha256", escape(dependency.getSha256()));
+            if (CollectionUtils.isNotEmpty(dependency.getProjectReferences())) {
+                row.put("dependency.projectReferences", escape(String.join(", ", dependency.getProjectReferences())));
+            }
             row.put("vulnerability.source", vulnerability.getSource());
             row.put("vulnerability.name", escape(vulnerability.getName()));
             row.put("vulnerability.nameLabel", createCellWithSortValue(generateVulnerabilityField(vulnerability), escape(vulnerability.getName())));

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/model/ReportParserTest.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -66,6 +67,18 @@ public class ReportParserTest {
         assertEquals("6.8", vulnerability.getCvssV2().getScore());
         assertEquals("8.8", vulnerability.getCvssV3().getBaseScore());
         assertEquals(Severity.HIGH, finding.getNormalizedSeverity());
+    }
+
+    @Test
+    public void testProjectReferences() throws Exception {
+        List<Finding> findings = ReportParser
+                .parse(getClass().getResourceAsStream("dependency-check-report-one-vulnerability.xml"));
+        assertNotNull(findings);
+        Finding finding = findings.get(0);
+        assertNotNull(finding);
+        List<String> projectReferences = finding.getDependency().getProjectReferences();
+        assertNotNull(projectReferences);
+        assertEquals(singletonList("example:compile"), projectReferences);
     }
 
     @Issue("JENKINS-73382")


### PR DESCRIPTION
Display project references in OWASP dependency check table.

See [JENKINS-74934](https://issues.jenkins.io/browse/JENKINS-74934) for more information.

Parse "dependency/projectReferences/projectReference" from the dependency-check XML, available in dependency-check.1.7.xsd through dependency-check.4.0.xsd (latest).

Then display the value in the Dependency-Check Reports table, and also make it filterable (searchable). 

### Testing done

Added test-case to verify that XML parsing works fine (see `ReportParserTest.testProjectReferences`)

Deployed plugin to Jenkins installation and verified that the plugin works as intended. 

Note that old jobs that were run with a previous version of the dependency-check plugin will not have the project references value populated in the table. It seems like the parsed Java objects are stored for historical jobs, rather than the original XML. However, new jobs will have value, as shown in the screenshot. 

Also verified that the new table field is searchable (worked out of the box). 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

### Screenshot

![Skärmavbild 2024-11-28 kl  11 11 01](https://github.com/user-attachments/assets/2e19f316-60a4-4ebf-8c35-4f5693862064)
