### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
     </parent>
     <artifactId>dependency-check-jenkins-plugin</artifactId>
     <name>OWASP Dependency-Check Plugin</name>
@@ -15,7 +15,7 @@
     <inceptionYear>2012</inceptionYear>
     <organization>
         <name>OWASP</name>
-        <url>http://www.owasp.org</url>
+        <url>https://www.owasp.org</url>
     </organization>
 
     <scm>
@@ -47,7 +47,7 @@
     <licenses>
         <license>
             <name>Apache-2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 
@@ -80,9 +80,10 @@
         <revision>5.6.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/dependency-check-plugin</gitHubRepo>
-        <jenkins.version>2.462.3</jenkins.version>
-        <jenkins-plugins-bom.artifactId>bom-2.462.x</jenkins-plugins-bom.artifactId>
-        <jenkins-plugins-bom.version>3850.vb_c5319efa_e29</jenkins-plugins-bom.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins-plugins-bom.version>4051.v78dce3ce8b_d6</jenkins-plugins-bom.version>
 
         <assertj.version>3.27.0</assertj.version>
         <checkstyle.version>10.21.1</checkstyle.version>
@@ -92,7 +93,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>${jenkins-plugins-bom.artifactId}</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>${jenkins-plugins-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractThresholdPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/AbstractThresholdPublisher.java
@@ -18,6 +18,8 @@ package org.jenkinsci.plugins.DependencyCheck;
 import hudson.tasks.Recorder;
 import org.jenkinsci.plugins.DependencyCheck.model.Thresholds;
 import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -28,6 +30,7 @@ import java.io.Serializable;
  */
 public abstract class AbstractThresholdPublisher extends Recorder implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 5849869400487825164L;
 
     private Integer unstableTotalCritical;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckPublisher.java
@@ -31,6 +31,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import jenkins.tasks.SimpleBuildStep;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DependencyCheckPublisher extends AbstractThresholdPublisher implements SimpleBuildStep {
 
+    @Serial
     private static final long serialVersionUID = -3849031519263613214L;
     private static final Logger LOGGER = LoggerFactory.getLogger(DependencyCheckPublisher.class);
     private static final String DEFAULT_PATTERN = "**/dependency-check-report.xml";
@@ -219,7 +221,7 @@ public class DependencyCheckPublisher extends AbstractThresholdPublisher impleme
         }
 
         @Override
-        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> aClass) {
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true; // as specified in jenkins.tasks.SimpleBuildStep
         }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilder.java
@@ -21,6 +21,7 @@ import static hudson.util.QuotedStringTokenizer.tokenize;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -86,6 +87,7 @@ import jenkins.tasks.SimpleBuildStep;
  */
 public class DependencyCheckToolBuilder extends Builder implements SimpleBuildStep, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4267818809512542424L;
 
     private final String odcInstallation;
@@ -363,7 +365,7 @@ public class DependencyCheckToolBuilder extends Builder implements SimpleBuildSt
         }
 
         @Override
-        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/ResultAction.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +45,7 @@ import net.sf.json.JsonConfig;
  */
 public class ResultAction extends BuildAction<DependencyCheckBuildResult> {
 
+    @Serial
     private static final long serialVersionUID = -6533677178186658819L;
 
     public ResultAction(final Run<?, ?> owner, List<Finding> findings, SeverityDistribution severityDistribution) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Analysis.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Analysis.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,6 +30,7 @@ import java.util.List;
  */
 public class Analysis implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3444323586874857295L;
 
     private ScanInfo scanInfo;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV2.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV2.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class CvssV2 implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3093529837834374013L;
 
     private String score;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV3.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/CvssV3.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class CvssV3 implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 9178656430054916373L;
 
     private String baseScore;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Dependency.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Objects;
  */
 public class Dependency implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1670679619302610671L;
 
     private String fileName;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Finding.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Finding.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
  */
 public class Finding implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 2916981097517354202L;
 
     private int count;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ProjectInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ProjectInfo.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class ProjectInfo implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -5430373059282763210L;
 
     private String name;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Reference.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Reference.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class Reference implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3633944367025966152L;
 
     private String source;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/RiskGate.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/RiskGate.java
@@ -16,6 +16,8 @@
 package org.jenkinsci.plugins.DependencyCheck.model;
 
 import hudson.model.Result;
+
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -26,6 +28,7 @@ import java.io.Serializable;
  */
 public class RiskGate implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 171256230735670985L;
 
     private Thresholds thresholds;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ScanInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/ScanInfo.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class ScanInfo implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -8845107789941894310L;
 
     private String engineVersion;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Severity.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Severity.java
@@ -33,19 +33,13 @@ public enum Severity {
         if (severity == null) {
             return Severity.UNASSIGNED;
         }
-        switch (severity.toUpperCase()) {
-        case "CRITICAL":
-            return Severity.CRITICAL;
-        case "HIGH":
-            return Severity.HIGH;
-        case "MEDIUM":
-            return Severity.MEDIUM;
-        case "MODERATE":
-            return Severity.MEDIUM;
-        case "LOW":
-            return Severity.LOW;
-        default:
-            return Severity.UNASSIGNED;
-        }
+        return switch (severity.toUpperCase()) {
+        case "CRITICAL" -> Severity.CRITICAL;
+        case "HIGH" -> Severity.HIGH;
+        case "MEDIUM" -> Severity.MEDIUM;
+        case "MODERATE" -> Severity.MEDIUM;
+        case "LOW" -> Severity.LOW;
+        default -> Severity.UNASSIGNED;
+        };
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/SeverityDistribution.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/SeverityDistribution.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class SeverityDistribution implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -8061827374550831502L;
 
     private int buildNumber;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Thresholds.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Thresholds.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -25,6 +26,7 @@ import java.io.Serializable;
  */
 public class Thresholds implements Serializable {
     public static class TotalFindings implements Serializable {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         public Integer unstableCritical;
@@ -39,6 +41,7 @@ public class Thresholds implements Serializable {
     }
 
     public static class NewFindings implements Serializable {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         public Integer unstableCritical;
@@ -52,6 +55,7 @@ public class Thresholds implements Serializable {
         public boolean limitToAnalysisExploitable;
     }
 
+    @Serial
     private static final long serialVersionUID = -6489027153777053306L;
 
     public final TotalFindings totalFindings = new TotalFindings();

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Vulnerability.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/model/Vulnerability.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Objects;
  */
 public class Vulnerability implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 2146048369342617342L;
 
     public enum Source {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStep.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStep.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.DependencyCheck.pipeline;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Set;
 
@@ -36,6 +37,7 @@ import hudson.model.TaskListener;
 
 public class DependencyCheckStep extends Step implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -251474850582356300L;
 
     private String pattern;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/pipeline/DependencyCheckStepExecutor.java
@@ -30,8 +30,11 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import java.io.Serial;
+
 public class DependencyCheckStepExecutor extends SynchronousNonBlockingStepExecution<Void> {
 
+    @Serial
     private static final long serialVersionUID = -8209320657657318589L;
 
     private DependencyCheckStep step;

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstallation.java
@@ -33,6 +33,7 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serial;
 import java.util.List;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang3.ArrayUtils;
@@ -51,6 +52,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class DependencyCheckInstallation extends ToolInstallation
         implements EnvironmentSpecific<DependencyCheckInstallation>, NodeSpecific<DependencyCheckInstallation> {
 
+    @Serial
     private static final long serialVersionUID = 6948241591210479899L;
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "calculate at runtime, its value depends on the OS where it run")

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstaller.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/DependencyCheckInstaller.java
@@ -60,7 +60,7 @@ public class DependencyCheckInstaller extends DownloadFromUrlInstaller {
         }
 
         if (installable instanceof NodeSpecific) {
-            installable = (Installable) ((NodeSpecific) installable).forNode(node, log);
+            installable = (Installable) ((NodeSpecific<?>) installable).forNode(node, log);
         }
 
         if (!isUpToDate(expected, installable)) {

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/Version.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/tools/Version.java
@@ -264,11 +264,10 @@ public class Version implements Comparable<Version> {
             return true;
         }
 
-        if (!(object instanceof Version)) {
+        if (!(object instanceof Version other)) {
             return false;
         }
 
-        Version other = (Version) object;
         return (major == other.major) && (minor == other.minor) && (micro == other.micro);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
+++ b/src/main/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformer.java
@@ -38,7 +38,7 @@ import net.sf.json.JSONObject;
 /**
  * Converts a list of Findings into a data structure suitable
  * for the FooTable Javascript component.
- *
+ * <p>
  * Ported from the Dependency-Track Jenkins plugin.
  *
  * @author Steve Springett (steve.springett@owasp.org)

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
 <div>
-    This plug-in can independently execute a <a href="http://www.owasp.org/index.php/OWASP_Dependency_Check">Dependency-Check</a> analysis and visualize results.
+    This plug-in can independently execute a <a href="https://www.owasp.org/index.php/OWASP_Dependency_Check">Dependency-Check</a> analysis and visualize results.
     <p>
         Dependency-Check is a utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities.
     </p>

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/DependencyCheckToolBuilderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -55,6 +56,7 @@ import hudson.util.ArgumentListBuilder;
 public class DependencyCheckToolBuilderTest {
 
     private static class MockDependencyCheckToolBuilder extends DependencyCheckToolBuilder {
+        @Serial
         private static final long serialVersionUID = 2630773000142173803L;
         private int exitCode;
 

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/aggregator/FindingsAggregatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/aggregator/FindingsAggregatorTest.java
@@ -32,14 +32,14 @@ public class FindingsAggregatorTest {
 
     private Finding createFinding(Severity severity, int idx) {
         Dependency dependency = new Dependency();
-        dependency.setFileName(severity.name() + String.valueOf(idx));
+        dependency.setFileName(severity.name() + idx);
         Vulnerability vulnerability = new Vulnerability();
         vulnerability.setSeverity(severity.name());
         return new Finding(dependency, vulnerability);
     }
 
     private List<Finding> createFindings(int critical, int high, int medium, int low, int info, int unassigned) {
-        List<Finding> findings = new ArrayList<Finding>();
+        List<Finding> findings = new ArrayList<>();
         for (int i = 1; i <= critical; i++) {
             findings.add(createFinding(Severity.CRITICAL, i));
         }

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/casc/JCasCTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/casc/JCasCTest.java
@@ -23,11 +23,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
 import org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstallation;
 import org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstaller;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.tools.InstallSourceProperty;
 import hudson.tools.ToolDescriptor;
@@ -35,14 +37,15 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 import hudson.tools.ToolPropertyDescriptor;
 import hudson.util.DescribableList;
-import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class JCasCTest extends RoundTripAbstractTest {
+@WithJenkins
+class JCasCTest extends AbstractRoundTripTest {
 
     @Override
-    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
-        checkInstallations(restartableJenkinsRule.j.jenkins);
+    protected void assertConfiguredAsExpected(JenkinsRule jenkinsRule, String s) {
+        checkInstallations(jenkinsRule.jenkins);
     }
 
     private void checkInstallations(Jenkins j) {

--- a/src/test/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/DependencyCheck/transformer/FindingsTransformerTest.java
@@ -38,7 +38,7 @@ class FindingsTransformerTest {
         sut = new FindingsTransformer() {
             @Override
             protected void initSymbols() {
-            };
+            }
         };
     }
 
@@ -66,9 +66,8 @@ class FindingsTransformerTest {
         assertThatJson(json).node("rows").isArray() //
                 .element(0).isObject() //
                 .node("vulnerability\\.references") //
-                .satisfies(value -> {
-                    assertThat(value).asString().contains("<a href=\"http://example.com/q?aaa&quot; onmouseover=alert(1) foo=&quot;a\" target=\"_blank\">asdfg</a>");
-                });
+                .satisfies(value ->
+                        assertThat(value).asString().contains("<a href=\"http://example.com/q?aaa&quot; onmouseover=alert(1) foo=&quot;a\" target=\"_blank\">asdfg</a>"));
     }
 
     private List<Finding> loadFindings(String resourceName) throws Exception {


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
